### PR TITLE
Fix actor sheets just showing the actor's portrait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.2.2
+
+* Fix a bug where opening a non-talent's sheet would result in just the actor's image being visible with nothing else
+
 ## 1.2.1
 
 * Update to support D&D5e 2.4.0

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This module also adds a new tab to the character sheet of your Talent for tracki
 ## FAQ
 
 ### **Q:** How do I add the Strain tab to a sheet?  
-**A:** Add a class to your character with a class identifier of `talent`
+**A:** Add a class to your character with a class identifier of `talent`. [Click here for a more in-depth walkthrough on how to do that](https://github.com/CeaneC/FoundryVTT-Talent/issues/3#issuecomment-1851985018).
 
 ### **Q:** How do I add powers to my spellbook?  
 **A:** Add a spell to your spellbook, and set the Spell Prepration Mode to Talent Power.   

--- a/module.json
+++ b/module.json
@@ -26,7 +26,7 @@
         "manifest": "https://raw.githubusercontent.com/foundryvtt/dnd5e/master/system.json",
         "compatibility": {
           "minimum": "2.4.0",
-          "verified": "2.4.0"
+          "verified": "2.4.1"
         }
       }
     ],

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -107,9 +107,12 @@ Hooks.once('ready', () => {
     events.push(renderAbilityUseDialogHook);
 })
 
+let setupComplete = false;
+
 Hooks.on('setup', () => {
     console.log(`${NAME} | Setting up ${KEY}`);
     setupPowerSpecialties();
+    setupComplete = true;
 });
 
 let lastUpdatedStrainActorId = null;
@@ -129,6 +132,7 @@ Hooks.on("updateActor", (actor, data, options, id) => {
 })
 
 Hooks.on("dnd5e.prepareLeveledSlots", (spells, actor, slots) => {
+    if (!setupComplete) return;
     saveActorIdOnStrainTab(actor);
 })
 


### PR DESCRIPTION
## What's the bug?

Opening a non-talent's character sheet results in Foundry using the Base Sheet, so that only the actor's portrait is visible and nothing else.

## Why is it happening?

Accessing the `sheet` property of an actor for the first time caches what sheet it uses so it doesn't have to call `_getSheetClass()` every time. The `dnd5e.prepareLeveledSlots` hook runs quite early - before the actors have been told that they're supposed to be using the `Actor5eCharacterSheet` sheet. This module has code that runs on that hook to check what the currently active tab on the sheet is. This causes the actors to cache the `BaseSheet` as the sheet to use, rather than the 5e one.

## How is it fixed?

Only run our `dnd5e.prepareLeveledSlots` hook's code after the `setup` hook is complete

## Notes

Fixes #4
