### PR TITLE
Fix missing power specialty icons

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,7 +119,7 @@ jobs:
             module.json                          \
             README.md                            \
             CHANGELOG.md                         \
-            images                               \
+            icons                                \
             templates/                           \
             scripts/                             \
             styles/                              \

--- a/module.json
+++ b/module.json
@@ -6,7 +6,7 @@
   "library": "false",
   "manifestPlusVersion": "1.2.0",
   "compatibility": {
-    "minimum": 10,
+    "minimum": 11,
     "verified": 11
   },
   "type": "module",


### PR DESCRIPTION
## What's the bug?
The power specialty icons aren't appearing in the spellbook

## Why is it happening?
The icons directory doesn't get packaged up by the release workflow

## How is it fixed?
Swap out the images directory in the packaging workflow for the icons directory (since users probably don't need the screenshots as part of the module)

## Notes
Also set minimum core version to v11, since it's now the minimum required by dnd5e 3.0.0
