### PR TITLE
Fix bug where spells would say "Manifest at Order"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.3
+
+* Fix a bug where all spells would say "Manifest at Order" instead of just talent powers, and spells would lose the "Consume slot" checkbox
+
 ## 1.3.2
 * Add support for D&D5e 3.1.0's Dark Theme
 * Fix Talent Power spell preparation mode showing up blank

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -54,7 +54,7 @@ const updateDebug = () => {
 };
 
 let renderAbilityUseDialogHookId = Hooks.on("renderAbilityUseDialog", (dialog, html, formData) => {
-    renderUsePowerDialog(dialog, html);
+    renderUsePowerDialog(dialog, html, formData);
 });
 
 Hooks.once('i18nInit', () => {

--- a/scripts/power-use-dialog.js
+++ b/scripts/power-use-dialog.js
@@ -1,8 +1,11 @@
 import { localise, spellLevelToOrder } from './utils.js';
 import { log } from "./module.js";
 
-export const renderUsePowerDialog = function(dialog, html) {
-    log.debug('renderUsePowerDialog', dialog, html);
+export const renderUsePowerDialog = function(dialog, html, formData) {
+    log.debug('renderUsePowerDialog', dialog, html, formData);
+
+    if (dialog.item.system.preparation.mode !== 'talent')
+        return;
 
     const spellHint = game.i18n.format("DND5E.AbilityUseHint", {
         type: game.i18n.localize(CONFIG.Item.typeLabels[dialog.item.type]),


### PR DESCRIPTION
## What's the bug?

All spells are being cast as talent powers, with the text "Manifest at Order" instead of "Cast at Level" and hiding the "Consume slot" checkbox

## Why is it happening?

The `renderUsePowerDialog` method is being called for all spells

## How is it fixed?

Return early if it's not a talent power being used

## Screenshots

Spells functioning normally again:
![image](https://github.com/CeaneC/FoundryVTT-Talent/assets/43473593/c99ce04f-884f-46db-b5ab-8db01be375ed)

Talent powers still functioning as talent powers:
![image](https://github.com/CeaneC/FoundryVTT-Talent/assets/43473593/987c1250-aa04-4d6f-a835-a29fa9787a85)

## Notes

Closes #11 