### PR TITLE
Fix class summary journals, add psionic exertions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.4.0
+
+* Add Psionic Exertions as a Class Feature Type
+* Fix a bug where Class Summary journals would throw errors when opened
+* Fix a bug where the Class Summary journal of a Talent wouldn't open
+
 ## 1.3.3
 
 * Fix a bug where all spells would say "Manifest at Order" instead of just talent powers, and spells would lose the "Consume slot" checkbox

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -57,8 +57,13 @@ let renderAbilityUseDialogHookId = Hooks.on("renderAbilityUseDialog", (dialog, h
     renderUsePowerDialog(dialog, html, formData);
 });
 
-Hooks.once('i18nInit', () => {
+Hooks.once('init', () => {
     console.log(`${NAME} | Initialising ${KEY}`);
+    CONFIG.DND5E.featureTypes.class.subtypes['psionicExertion'] = `${KEY}.PsionicExertion`;
+});
+
+Hooks.once('i18nInit', () => {
+    console.log(`${NAME} | Initialising Internationalisation ${KEY}`);
     registerSettings();
     updateDebug();
     setupPowerSpecialties();
@@ -167,7 +172,7 @@ Hooks.on('dnd5e.computeTalentProgression', (progression, actor, cls, spellcastin
 
 
 Hooks.on('dnd5e.buildTalentSpellcastingTable', (table, item, spellcasting) => {
-    table.headers ??= ["F"];
+    table.headers ??= [""];
     table.cols ??= [ { class: 'spellcasting', span: 0 } ]
 });
 

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -165,6 +165,12 @@ Hooks.on('dnd5e.computeTalentProgression', (progression, actor, cls, spellcastin
     progression.talent += cls.system.levels;
 });
 
+
+Hooks.on('dnd5e.buildTalentSpellcastingTable', (table, item, spellcasting) => {
+    table.headers ??= ["F"];
+    table.cols ??= [ { class: 'spellcasting', span: 0 } ]
+});
+
 Hooks.on('dnd5e.prepareTalentSlots', (spells, actor, progression) => {
     let talentLevel = Math.clamped(progression.talent, 0, CONFIG.DND5E.maxLevel);
 
@@ -245,6 +251,8 @@ Hooks.on("dnd5e.prepareLeveledSlots", (spells, actor, slots) => {
 })
 
 function saveActorIdOnStrainTab(actor) {
+    if (!actor) return;
+
     if (actor.sheet._tabs[0]?.active == 'strain') {
         lastUpdatedStrainActorId = actor._id;
     } else {


### PR DESCRIPTION
Closes #13 and closes #14

## What's the bug?

* Class Summary journals do not render for classes with Talent spellcasting progression
* Viewing any other class summary journal causes errors in the console

## Why is it happening?

* When the system tries to retrieve the spellcasting table, the talent's casting doesn't give any headers
* The method to save an actor's ID on the strain tab is running, but no actor is being passed in

## How is it fixed?

* Add a hook to populate the talent spellcasting table, but just give it dummy data so it doesn't actually render anything
* Return if actor is null

## Screenshots

![Talent class summary journal](https://github.com/CeaneC/FoundryVTT-Talent/assets/43473593/ebd8332b-3bff-4b28-a5f2-f9c94c817abf)

![Psionic exertion in dropdown](https://github.com/CeaneC/FoundryVTT-Talent/assets/43473593/8a93b3c5-f1bb-4b04-ab98-f40e29961921)

## Notes

Also added psionic exertions as a class feature
