### PR TITLE
Fix missing localisation for Psionic Exertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.1
+
+* Fix missing localisation for Psionic Exertion
+
 ## 1.4.0
 
 * Add Psionic Exertions as a Class Feature Type

--- a/languages/en.json
+++ b/languages/en.json
@@ -57,6 +57,8 @@
         "PowerUsage": "Power Usage",
         "PowerTarget": "Power Target",
         "SpellPrepTalent": "Talent Power",
+
+        "PsionicExertion": "Psionic Exertion",
     
         "Strain": "Strain",
 


### PR DESCRIPTION
## What's the bug?

Psionic Exertion isn't being localised:

## Why is it happening?

The relevant entry is missing from the localisation file

## How is it fixed?

Add the missing entry

## Screenshots

![image](https://github.com/CeaneC/FoundryVTT-Talent/assets/123265319/1664cd06-7e1b-430b-a1ea-390320f19c5b)

## Notes

Closes #16 